### PR TITLE
Split query setting into a separate useEffect, added a guard around t…

### DIFF
--- a/src/Assignments/SimpleProblemPage.tsx
+++ b/src/Assignments/SimpleProblemPage.tsx
@@ -152,7 +152,7 @@ export const SimpleProblemPage: React.FC<SimpleProblemPageProps> = () => {
 
             // If a selectedProblemId hasn't been set by the query parameter or is invalid, set it to the first id.
             if (_.isNil(selectedProblemId) || !_.some(problems, ['id', selectedProblemId])) {
-                setSelectedProblemId(_.sortBy(problems, ['problemNumber'])[0].id);
+                setSelectedProblemId(_.sortBy(problems, ['problemNumber']).first?.id ?? null);
             }
 
             if (!_.isNil(currentTopic.topicAssessmentInfo) &&

--- a/src/Assignments/SimpleProblemPage.tsx
+++ b/src/Assignments/SimpleProblemPage.tsx
@@ -74,13 +74,16 @@ export const SimpleProblemPage: React.FC<SimpleProblemPageProps> = () => {
     useEffect(() => {
         logger.info('SimpleProblemPage: selected problem has changed');
         resetAlert();
+    }, [selectedProblemId, resetAlert]);
+
+    useEffect(() => {
         updateRoute({
             problemId: {
                 mode: QueryStringMode.OVERWRITE,
                 val: selectedProblemId?.toString() ?? null,
             }
         });
-    }, [selectedProblemId, resetAlert, updateRoute]);
+    }, [selectedProblemId, updateRoute]);
 
     useEffect(() => {
         logger.info('SimpleProblemPage: topic or version or attempts remaining has changed');
@@ -146,7 +149,12 @@ export const SimpleProblemPage: React.FC<SimpleProblemPageProps> = () => {
                 .keyBy('id')
                 .value();
             setProblems(problemDictionary);
-            setSelectedProblemId(_.sortBy(problems, ['problemNumber'])[0].id);
+
+            // If a selectedProblemId hasn't been set by the query parameter or is invalid, set it to the first id.
+            if (_.isNil(selectedProblemId) || !_.some(problems, ['id', selectedProblemId])) {
+                setSelectedProblemId(_.sortBy(problems, ['problemNumber'])[0].id);
+            }
+
             if (!_.isNil(currentTopic.topicAssessmentInfo) &&
                 !_.isNil(currentTopic.topicAssessmentInfo.studentTopicAssessmentInfo) &&
                 currentTopic.topicAssessmentInfo.studentTopicAssessmentInfo.length > 0 // student has generated at least one version already


### PR DESCRIPTION
…he initial override of the problemId.